### PR TITLE
Emscripten support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,21 @@ INCS      = -I.
 LDFLAGS   =
 LIBS      = -lm
 
-ifndef SDL2
+ifdef EMSCRIPTEN
+NAME     := wetspot2.js
+CC       := emcc
+CFLAGS   += -DUSE_SDL2 -s USE_SDL=2 -s USE_SDL_MIXER=2 -s USE_SDL_GFX=2 \
+	    -s SDL2_MIXER_FORMATS=wav,mid -s SDL2_IMAGE_FORMATS=bmp
+LDFLAGS  += -s ASYNCIFY --use-preload-plugins --embed-file data \
+	    --embed-file world -sALLOW_MEMORY_GROWTH -lSDL2 -lSDL2_gfx \
+		-lSDL2_mixer
+else ifndef SDL2
 # SDL1.2 defines
 CFLAGS   += `sdl-config --cflags`
 LIBS     += -lSDL -lSDL_gfx -lSDL_mixer
 else
 # SDL2 defines
-CFLAGS   += `sdl2-config --cflags` -DUSE_SDL2
+CFLAGS   += `sdl2-config --cflags` -DUSE_SDL2 
 LIBS     += -lSDL2 -lSDL2_gfx -lSDL2_mixer
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 NAME      = wetspot2
 CC        = gcc
-CFLAGS    = -g -O2 -Wall -Wextra -Wno-unused -std=c99 -fms-extensions \
+CFLAGS    = -g -O2 -Wall -Wextra -Wno-unused -fms-extensions \
 	    -DSCALE_SCREEN
 INCS      = -I.
 LDFLAGS   =
@@ -15,17 +15,17 @@ ifdef EMSCRIPTEN
 NAME     := wetspot2.js
 CC       := emcc
 CFLAGS   += -DUSE_SDL2 -s USE_SDL=2 -s USE_SDL_MIXER=2 -s USE_SDL_GFX=2 \
-	    -s SDL2_MIXER_FORMATS=wav,mid -s SDL2_IMAGE_FORMATS=bmp
+	    -s SDL2_MIXER_FORMATS=wav,mid -s SDL2_IMAGE_FORMATS=bmp -std=gnu99
 LDFLAGS  += -s ASYNCIFY --use-preload-plugins --embed-file data \
 	    --embed-file world -sALLOW_MEMORY_GROWTH -lSDL2 -lSDL2_gfx \
-		-lSDL2_mixer
+		-lSDL2_mixer -lidbfs.js -s FORCE_FILESYSTEM
 else ifndef SDL2
 # SDL1.2 defines
-CFLAGS   += `sdl-config --cflags`
+CFLAGS   += `sdl-config --cflags` -std=c99
 LIBS     += -lSDL -lSDL_gfx -lSDL_mixer
 else
 # SDL2 defines
-CFLAGS   += `sdl2-config --cflags` -DUSE_SDL2 
+CFLAGS   += `sdl2-config --cflags` -DUSE_SDL2  -std=c99
 LIBS     += -lSDL2 -lSDL2_gfx -lSDL2_mixer
 endif
 

--- a/hiscore.c
+++ b/hiscore.c
@@ -22,6 +22,9 @@
 #include <time.h>
 #include <SDL.h>
 #include <SDL_mixer.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 #include "wetspot2.h"
 #include "font.h"
@@ -56,7 +59,11 @@ FIREWORKTYPE FireWork[MAXFIREWORKS];
 RECORDTYPE Record[10];
 float fx[50], fy[50];
 
+#ifndef __EMSCRIPTEN__
 char homepath[256] = "./";
+#else
+char homepath[256] = "/WETSPOT2";
+#endif
 
 void PathInit()
 {
@@ -338,6 +345,13 @@ void CheckForRecord()
 	}
 
 	SaveRecord();
+#ifdef __EMSCRIPTEN__
+	EM_ASM(
+		// Persist local copy to IndexedDB
+		FS.syncfs(false, _ => { });
+	);
+#endif
+
 
 	// Shows the updated top 10 players list
 	ShowTop10(Blink[0], Blink[1]);

--- a/timer.c
+++ b/timer.c
@@ -22,6 +22,9 @@
 #include <math.h>
 #include <SDL.h>
 #include <SDL_mixer.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 #include "wetspot2.h"
 #include "font.h"
@@ -38,7 +41,7 @@ SDL_TimerID timer_id;
 int TimerOn = FALSE;
 
 // timer routine
-Uint32 TimePass(Uint32 interval/*, void *param*/)
+Uint32 TimePass(Uint32 interval, void *param)
 {
 	if(TimerOn)
 		Game.time--;
@@ -135,6 +138,18 @@ void Wait()
 
 	if(next_game_tick == 17) next_game_tick += frame_end;
 	sleep_time = next_game_tick - frame_end;
-	if(sleep_time > 0) SDL_Delay(sleep_time); else SDL_Delay(2);
+	if(sleep_time > 0) {
+#ifdef __EMSCRIPTEN__
+		emscripten_sleep(sleep_time);
+#else
+		SDL_Delay(sleep_time); 
+#endif
+	} else {
+#ifdef __EMSCRIPTEN__
+		emscripten_sleep(2);
+#else
+		SDL_Delay(2); 
+#endif
+	}
 	if(frames == 0) frame_start = next_game_tick;
 }

--- a/wetspot2.c
+++ b/wetspot2.c
@@ -2256,6 +2256,13 @@ int main(int argc, char* argv[])
 	int result;
 
 #ifdef __EMSCRIPTEN__
+    EM_ASM(
+        // Mount IndexedDB storage for high scores
+        FS.mkdir('/WETSPOT2');
+        FS.mount(IDBFS, {}, '/WETSPOT2');
+        FS.syncfs(true, _ => {}); // Load IndexedDB data
+    );
+
 	// Main loop is required for SDL_AddTimer to work under Emscripten
 	emscripten_set_main_loop(nop, 0, 0);
 	result = SDL_Init(SDL_INIT_TIMER);

--- a/wetspot2.c
+++ b/wetspot2.c
@@ -22,6 +22,9 @@
 #include <time.h>
 #include <SDL.h>
 #include <SDL_mixer.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 #include "wetspot2.h"
 #include "font.h"
@@ -2244,12 +2247,21 @@ void InitGame()
 	LoadWorld("./world/WETSPOT2.WWD");
 }
 
-#undef main
-int main()
+#ifdef __EMSCRIPTEN__
+void nop() { }
+#endif
+
+int main(int argc, char* argv[])
 {
 	int result;
 
+#ifdef __EMSCRIPTEN__
+	// Main loop is required for SDL_AddTimer to work under Emscripten
+	emscripten_set_main_loop(nop, 0, 0);
+	result = SDL_Init(SDL_INIT_TIMER);
+#else
 	result = SDL_Init(SDL_INIT_EVERYTHING);
+#endif
 	if(result) {
 		printf("Failed to init SDL\n");
 		exit(1);


### PR DESCRIPTION
Updated to support building with Emscripten to run in the browser: 
https://spontaneous-lebkuchen-4449f6.netlify.app/

I used to play this all the time with my brother growing up. But the emulated version of the QuickBASIC original that's available on Internet Archive has a download delay and some performance and playability issues. The WASM build of this remake runs smoothly, without an initial loading screen, in a lighter (but still 5MB) package.

With Asyncify, it required fewer changes than I thought it would. This change adds preprocessor switches that swap out SDL_Delay for emscripten_sleep, and initiate a main loop for timing. While I can't verify how it affects building for the GCW-Zero platform it was meant for, the SDL2 native build still works on my MacBook Air (while the SDL1 build doesn't work for me with sdl12-compat).