### PR TITLE
Fix Emscripten audio

### DIFF
--- a/sound.c
+++ b/sound.c
@@ -137,11 +137,15 @@ void SoundInit()
 	Mix_Init(0);
 	Mix_OpenAudio(22050, MIX_DEFAULT_FORMAT, 2, 1024);
 
+	int frequency;
+	int format;
+	int channels;
+	Mix_QuerySpec(&frequency, &format, &channels);
 	atexit(Mix_Quit);
 	atexit(Mix_CloseAudio);
 	atexit(SoundDeinit);
 
-	mid_init(22050, 2);
+	mid_init(frequency, channels);
 }
 
 void SoundDeinit()


### PR DESCRIPTION
https://65c496d6b74af85155d6496a--spontaneous-lebkuchen-4449f6.netlify.app/

The fast music when using Emscripten appears to be because the browser has the right to override the frequency in `Mix_OpenAudio` to use whatever its default is. In this case, Chrome is defaulting to 44k, causing the samples to play twice as fast.

Fixed by querying the frequency with `Mix_QueryAudio`, and sending that value to `mid_init` instead of hard-coding 22k. Now the audio plays normally for me both natively and in the browser.